### PR TITLE
CORE-834: Add System::accountInitialize(_:onNetwork:using) and associated.

### DIFF
--- a/WalletKit/BRCryptoSystem.swift
+++ b/WalletKit/BRCryptoSystem.swift
@@ -86,72 +86,6 @@ public final class System {
     }
 
     ///
-    /// Check if `account` is initialized for `network`.  Some networks require that accounts
-    /// be initialized before they can be used; Hedera is one such network.
-    ///
-    /// - Parameters:
-    ///   - account: the account
-    ///   - network: the network
-    ///   
-    /// - Returns: `true` if initialized; `false` otherwise
-    ///
-    public func accountIsInitialized (_ account: Account, onNetwork network: Network) -> Bool {
-        return CRYPTO_TRUE == cryptoNetworkIsAccountInitialized (network.core, account.core)
-    }
-
-
-    /// Initialize `account` on `network` using `data`.  The provided data is network specific and
-    /// thus an opaque sequence of bytes.
-    ///
-    /// - Parameters:
-    ///   - account: the account
-    ///   - network: the network
-    ///   - data: the data
-    ///
-    /// - Returns: The account serialization or `nil` if the account was already initialized.  This
-    ///            serialization must be saved otherwise the initialization will be lost upon the
-    ///            next System start.
-    ///
-    public func accountInitialize (_ account: Account, onNetwork network: Network, using data: Data) -> Data? {
-        guard !accountIsInitialized (account, onNetwork: network)
-            else { return nil }
-
-        return data.withUnsafeBytes { (dataBytes: UnsafeRawBufferPointer) -> Data in
-            let dataAddr  = dataBytes.baseAddress?.assumingMemoryBound(to: UInt8.self)
-            let dataCount = dataBytes.count
-
-            cryptoNetworkInitializeAccount (network.core,
-                                            account.core,
-                                            dataAddr,
-                                            dataCount)
-            return account.serialize
-        }
-    }
-
-    /// Get the data needed to initialize `account` on `network`.  This data is network specfic and
-    /// thus an opaqe sequence of bytes.  The bytes are provided to some 'initialization provider'
-    /// in a network specific manner; the provider's result is passed back using the
-    /// `accountInitialize` function.
-    ///
-    /// - Parameters:
-    ///   - account: the account
-    ///   - network: the network
-    ///
-    /// - Returns: Opaque data to be provided to the 'initialization provider'
-    ///
-    public func accountGetInitializationdData (_ account: Account, onNetwork network: Network) -> Data? {
-        var bytesCount: BRCryptoCount = 0
-        return cryptoNetworkGetAccountInitializationData (network.core,
-                                                          account.core,
-                                                          &bytesCount)
-            .map {
-                let bytes = $0
-                defer { cryptoMemoryFree (bytes) }
-                return Data (bytes: bytes, count: bytesCount)
-        }
-    }
-
-    ///
     /// Create a wallet manager for `network` using `mode`, `addressScheme`, and `currencies`.  A
     /// wallet will be 'registered' for each of:
     ///    a) the network's currency - this is the primaryWallet
@@ -182,7 +116,7 @@ public final class System {
         precondition (network.supportsMode(mode))
         precondition (network.supportsAddressScheme(addressScheme))
 
-        guard accountIsInitialized (account, onNetwork: network),
+        guard account.isInitialized (onNetwork: network),
             let manager = WalletManager (system: self,
                                          callbackCoordinator: callbackCoordinator,
                                          account: account,

--- a/WalletKitDemo/Source/CoreDemoAppDelegate.swift
+++ b/WalletKitDemo/Source/CoreDemoAppDelegate.swift
@@ -122,7 +122,7 @@ class CoreDemoAppDelegate: UIResponder, UIApplicationDelegate, UISplitViewContro
             "eth" : .api_only,
             "bch" : .p2p_only,
             "xrp" : .api_only,
-//            "hbar" : .api_only
+            "hbar" : .api_only
             ]
         if mainnet {
 
@@ -341,9 +341,10 @@ extension UIApplication {
             let alert = UIAlertController (title: "Block Chain Access",
                                            message: "Can't access '\(network.name)'",
                 preferredStyle: UIAlertController.Style.alert)
+
             alert.addAction (UIAlertAction (title: "Okay", style: UIAlertAction.Style.cancel))
-                app.summaryController.present (alert, animated: true) {}
-            }
+            app.summaryController.present (alert, animated: true) {}
+        }
     }
 
     static func peer (network: Network) -> NetworkPeer? {
@@ -374,3 +375,22 @@ extension Network {
     }
 }
 
+// https://stackoverflow.com/a/40089462/1286639
+extension Data {
+    struct HexEncodingOptions: OptionSet {
+        let rawValue: Int
+        static let upperCase = HexEncodingOptions(rawValue: 1 << 0)
+    }
+
+    func asHexEncodedString (prefix: String = "",
+                             options: HexEncodingOptions = []) -> String {
+        let hexDigits = Array((options.contains(.upperCase) ? "0123456789ABCDEF" : "0123456789abcdef").utf16)
+        var chars: [unichar] = []
+        chars.reserveCapacity(2 * count)
+        for byte in self {
+            chars.append(hexDigits[Int(byte / 16)])
+            chars.append(hexDigits[Int(byte % 16)])
+        }
+        return prefix + String(utf16CodeUnits: chars, count: chars.count)
+    }
+}

--- a/WalletKitDemo/Source/CoreDemoListener.swift
+++ b/WalletKitDemo/Source/CoreDemoListener.swift
@@ -114,6 +114,22 @@ class CoreDemoListener: SystemListener {
                                                           currencies: currencies)
                 if !success {
                     system.wipe (network: network)
+
+                    // Recover if account is not initialized
+                    if !system.accountIsInitialized(system.account, onNetwork: network) {
+                        let dataForInitialization = system.accountGetInitializationdData (system.account, onNetwork: network)!
+                        print ("APP: Account: InitializationData: \(dataForInitialization.asHexEncodedString())")
+
+                        if network.type == .hbar {
+                            let initializationData = "0.0.114008".data(using: .utf8)!
+                            print ("APP: Account: InitializationResult: \(String(data: initializationData, encoding: .utf8)!)")
+
+                            let serializationData = system.accountInitialize (system.account, onNetwork: network, using: initializationData)
+                            print ("APP: Account: Serialization: \(serializationData?.asHexEncodedString() ?? "")")
+                        }
+                        print ("APP: Account: Initialized: \(system.accountIsInitialized(system.account, onNetwork: network))")
+                    }
+
                     let successRetry = system.createWalletManager (network: network,
                                                                    mode: mode,
                                                                    addressScheme: scheme,

--- a/WalletKitDemo/Source/CoreDemoListener.swift
+++ b/WalletKitDemo/Source/CoreDemoListener.swift
@@ -115,19 +115,22 @@ class CoreDemoListener: SystemListener {
                 if !success {
                     system.wipe (network: network)
 
+                    let account = system.account
+
                     // Recover if account is not initialized
-                    if !system.accountIsInitialized(system.account, onNetwork: network) {
-                        let dataForInitialization = system.accountGetInitializationdData (system.account, onNetwork: network)!
+                    if !account.isInitialized(onNetwork: network) {
+                        let dataForInitialization = account.getInitializationdData (onNetwork: network)!
                         print ("APP: Account: InitializationData: \(dataForInitialization.asHexEncodedString())")
 
                         if network.type == .hbar {
+                            // TODO: Remove stubbed data of "0.0.114008"
                             let initializationData = "0.0.114008".data(using: .utf8)!
                             print ("APP: Account: InitializationResult: \(String(data: initializationData, encoding: .utf8)!)")
 
-                            let serializationData = system.accountInitialize (system.account, onNetwork: network, using: initializationData)
+                            let serializationData = account.initialize (onNetwork: network, using: initializationData)
                             print ("APP: Account: Serialization: \(serializationData?.asHexEncodedString() ?? "")")
                         }
-                        print ("APP: Account: Initialized: \(system.accountIsInitialized(system.account, onNetwork: network))")
+                        print ("APP: Account: Initialized: \(account.isInitialized (onNetwork: network))")
                     }
 
                     let successRetry = system.createWalletManager (network: network,


### PR DESCRIPTION
Also, update the Swift Demo App to optionally initialize the Hedera network (using a faked initialization data).

[Draft until CORE-834 in walletkit-core.]