### PR TITLE
CORE-851: Extend AccountSpecification with a property `hedera: String?`

### DIFF
--- a/WalletKit/common/BRSupport.swift
+++ b/WalletKit/common/BRSupport.swift
@@ -243,11 +243,13 @@ public struct AccountSpecification {
     public let network: String
     public let paperKey: String
     public let timestamp: Date
+    public let hedera: String? // an associated accountID/address
 
     init (dict: [String: String]) {
         self.identifier = dict["identifier"]! //as! String
         self.network    = dict["network"]!
         self.paperKey   = dict["paperKey"]!
+        self.hedera     = dict["hedera"]
 
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd"

--- a/WalletKitDemo/Source/CoreDemoAppDelegate.swift
+++ b/WalletKitDemo/Source/CoreDemoAppDelegate.swift
@@ -212,6 +212,10 @@ extension UIApplication {
         return (UIApplication.shared.delegate as! CoreDemoAppDelegate).accountSpecification.paperKey
     }
 
+    static var accountSpecification: AccountSpecification {
+        return (UIApplication.shared.delegate as! CoreDemoAppDelegate).accountSpecification
+    }
+
     static func doSync () {
         guard let app = UIApplication.shared.delegate as? CoreDemoAppDelegate else { return }
         print ("APP: Syncing")

--- a/WalletKitDemo/Source/CoreDemoListener.swift
+++ b/WalletKitDemo/Source/CoreDemoListener.swift
@@ -123,12 +123,17 @@ class CoreDemoListener: SystemListener {
                         print ("APP: Account: InitializationData: \(dataForInitialization.asHexEncodedString())")
 
                         if network.type == .hbar {
-                            // TODO: Remove stubbed data of "0.0.114008"
-                            let initializationData = "0.0.114008".data(using: .utf8)!
-                            print ("APP: Account: InitializationResult: \(String(data: initializationData, encoding: .utf8)!)")
+                            var initializationData: Data? = nil
+                            DispatchQueue.main.sync {
+                                initializationData = UIApplication.accountSpecification.hedera
+                                    .map { $0.data(using: .utf8)! }
+                            }
+                            if let initializationData = initializationData {
+                                print ("APP: Account: InitializationResult: \(String(data: initializationData, encoding: .utf8)!)")
 
-                            let serializationData = account.initialize (onNetwork: network, using: initializationData)
-                            print ("APP: Account: Serialization: \(serializationData?.asHexEncodedString() ?? "")")
+                                let serializationData = account.initialize (onNetwork: network, using: initializationData)
+                                print ("APP: Account: Serialization: \(serializationData?.asHexEncodedString() ?? "")")
+                            }
                         }
                         print ("APP: Account: Initialized: \(account.isInitialized (onNetwork: network))")
                     }


### PR DESCRIPTION
For the Swift Demo App, allows an Hedera accountID to be 'automatically' initialized.